### PR TITLE
Fix "call of overloaded 'lerp' is ambiguous"

### DIFF
--- a/src/shapes/metrics_path.cpp
+++ b/src/shapes/metrics_path.cpp
@@ -106,6 +106,10 @@ static float segmentCubic(const Vec2D& from,
     return runningLength;
 }
 
+static float calcLerp(float from, float to, float f) {
+    return from + f * (to - from);
+}
+
 float MetricsPath::computeLength(const Mat2D& transform) {
     // If the pre-computed length is still valid (transformed with the same
     // transform) just return that.
@@ -244,8 +248,6 @@ void MetricsPath::trim(float startLength, float endLength, bool moveTo, RenderPa
     }
 }
 
-float lerp(float from, float to, float f) { return from + f * (to - from); }
-
 void MetricsPath::extractSubPart(
     int index, float startT, float endT, bool moveTo, RenderPath* result) {
     assert(startT >= 0.0f && startT <= 1.0f && endT >= 0.0f && endT <= 1.0f);
@@ -283,7 +285,7 @@ void MetricsPath::extractSubPart(
 
                             float t =
                                 (startLength - previousLength) / (segment.length - previousLength);
-                            startT = lerp(m_CubicSegments[si - 1].t, segment.t, t);
+                            startT = calcLerp(m_CubicSegments[si - 1].t, segment.t, t);
                         }
                         // Help out the ending segment finder by setting its
                         // start to where we landed while finding the first
@@ -306,7 +308,7 @@ void MetricsPath::extractSubPart(
 
                             float t =
                                 (endLength - previousLength) / (segment.length - previousLength);
-                            endT = lerp(m_CubicSegments[si - 1].t, segment.t, t);
+                            endT = calcLerp(m_CubicSegments[si - 1].t, segment.t, t);
                         }
                         break;
                     }


### PR DESCRIPTION
lerp function in `src/shapes/metrics_path.cpp` was causing an error:
`error: call of overloaded ‘lerp(float&, const float&, float&)’ is ambiguous`

```
/usr/include/c++/9/cmath:1919:3: note: candidate: ‘constexpr long double std::lerp(long double, long double, long double)’
 1919 |   lerp(long double __a, long double __b, long double __t) noexcept
      |   ^~~~
/usr/include/c++/9/cmath:1915:3: note: candidate: ‘constexpr double std::lerp(double, double, double)’
 1915 |   lerp(double __a, double __b, double __t) noexcept
      |   ^~~~
/usr/include/c++/9/cmath:1911:3: note: candidate: ‘constexpr float std::lerp(float, float, float)’
 1911 |   lerp(float __a, float __b, float __t) noexcept
      |   ^~~~
../submodule/rive-cpp/src/shapes/metrics_path.cpp:247:7: note: candidate: ‘float lerp(float, float, float)’
  247 | float lerp(float from, float to, float f) { return from + f * (to - from); }
      |       ^~~~
ninja: build stopped: subcommand failed.
```

Function was renamed to `calcLerp`.