### PR TITLE
Use our own PI

### DIFF
--- a/include/rive/math/math_types.hpp
+++ b/include/rive/math/math_types.hpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Rive
+ */
+
+#ifndef _RIVE_MATH_TYPES_DEFINED_
+#define _RIVE_MATH_TYPES_DEFINED_
+
+#include "rive/rive_types.hpp"
+#include <cmath>
+
+namespace rive {
+
+namespace math {
+    constexpr float PI = 3.14159265f;
+}
+
+}
+
+#endif

--- a/src/constraints/ik_constraint.cpp
+++ b/src/constraints/ik_constraint.cpp
@@ -1,8 +1,8 @@
 #include "rive/constraints/ik_constraint.hpp"
 #include "rive/bones/bone.hpp"
 #include "rive/artboard.hpp"
+#include "rive/math/math_types.hpp"
 #include <algorithm>
-#include <math.h> // M_PI
 
 using namespace rive;
 
@@ -139,17 +139,17 @@ void IKConstraint::solve2(BoneChainLink* fk1,
 
         if (invertDirection()) {
             r1 = std::atan2(cv[1], cv[0]) - A;
-            r2 = -C + M_PI + angleCorrection;
+            r2 = -C + math::PI + angleCorrection;
         } else {
             r1 = A + std::atan2(cv[1], cv[0]);
-            r2 = C - M_PI + angleCorrection;
+            r2 = C - math::PI + angleCorrection;
         }
     } else if (invertDirection()) {
         r1 = std::atan2(cv[1], cv[0]) - A;
-        r2 = -C + M_PI;
+        r2 = -C + math::PI;
     } else {
         r1 = A + std::atan2(cv[1], cv[0]);
-        r2 = C - M_PI;
+        r2 = C - math::PI;
     }
 
     constrainRotation(*fk1, r1);
@@ -237,13 +237,13 @@ void IKConstraint::constrain(TransformComponent* component) {
     // At the end, mix the FK angle with the IK angle by strength
     if (strength() != 1.0f) {
         for (BoneChainLink& fk : m_FkChain) {
-            float fromAngle = std::fmod(fk.transformComponents.rotation(), (float)M_PI * 2);
-            float toAngle = std::fmod(fk.angle, (float)M_PI * 2);
+            float fromAngle = std::fmod(fk.transformComponents.rotation(), math::PI * 2);
+            float toAngle = std::fmod(fk.angle, math::PI * 2);
             float diff = toAngle - fromAngle;
-            if (diff > M_PI) {
-                diff -= M_PI * 2;
-            } else if (diff < -M_PI) {
-                diff += M_PI * 2;
+            if (diff > math::PI) {
+                diff -= math::PI * 2;
+            } else if (diff < -math::PI) {
+                diff += math::PI * 2;
             }
             float angle = fromAngle + diff * strength();
             constrainRotation(fk, angle);

--- a/src/constraints/rotation_constraint.cpp
+++ b/src/constraints/rotation_constraint.cpp
@@ -1,7 +1,7 @@
 #include "rive/constraints/rotation_constraint.hpp"
 #include "rive/transform_component.hpp"
 #include "rive/math/mat2d.hpp"
-#include <cmath>
+#include "rive/math/math_types.hpp"
 
 using namespace rive;
 
@@ -69,14 +69,14 @@ void RotationConstraint::constrain(TransformComponent* component) {
         m_ComponentsB = transformB.decompose();
     }
 
-    float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI * 2);
-    float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI * 2);
+    float angleA = std::fmod(m_ComponentsA.rotation(), math::PI * 2);
+    float angleB = std::fmod(m_ComponentsB.rotation(), math::PI * 2);
     float diff = angleB - angleA;
 
-    if (diff > M_PI) {
-        diff -= M_PI * 2;
-    } else if (diff < -M_PI) {
-        diff += M_PI * 2;
+    if (diff > math::PI) {
+        diff -= math::PI * 2;
+    } else if (diff < -math::PI) {
+        diff += math::PI * 2;
     }
 
     m_ComponentsB.rotation(m_ComponentsA.rotation() + diff * strength());

--- a/src/constraints/transform_constraint.cpp
+++ b/src/constraints/transform_constraint.cpp
@@ -1,7 +1,7 @@
 #include "rive/constraints/transform_constraint.hpp"
 #include "rive/transform_component.hpp"
 #include "rive/math/mat2d.hpp"
-#include <cmath>
+#include "rive/math/math_types.hpp"
 
 using namespace rive;
 
@@ -29,13 +29,13 @@ void TransformConstraint::constrain(TransformComponent* component) {
     m_ComponentsA = transformA.decompose();
     m_ComponentsB = transformB.decompose();
 
-    float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI * 2);
-    float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI * 2);
+    float angleA = std::fmod(m_ComponentsA.rotation(), math::PI * 2);
+    float angleB = std::fmod(m_ComponentsB.rotation(), math::PI * 2);
     float diff = angleB - angleA;
-    if (diff > M_PI) {
-        diff -= M_PI * 2;
-    } else if (diff < -M_PI) {
-        diff += M_PI * 2;
+    if (diff > math::PI) {
+        diff -= math::PI * 2;
+    } else if (diff < -math::PI) {
+        diff += math::PI * 2;
     }
 
     float t = strength();

--- a/src/shapes/polygon.cpp
+++ b/src/shapes/polygon.cpp
@@ -1,6 +1,7 @@
 #include "rive/shapes/polygon.hpp"
 #include "rive/shapes/star.hpp"
 #include "rive/shapes/straight_vertex.hpp"
+#include "rive/math/math_types.hpp"
 #include <cmath>
 
 using namespace rive;
@@ -22,8 +23,8 @@ void Polygon::buildPolygon() {
     auto ox = -originX() * width() + halfWidth;
     auto oy = -originY() * height() + halfHeight;
 
-    auto angle = -M_PI / 2;
-    auto inc = 2 * M_PI / points();
+    auto angle = -math::PI / 2;
+    auto inc = 2 * -math::PI / points();
 
     for (StraightVertex& vertex : m_PolygonVertices) {
         vertex.x(ox + cos(angle) * halfWidth);

--- a/src/shapes/star.cpp
+++ b/src/shapes/star.cpp
@@ -1,5 +1,6 @@
 #include "rive/shapes/star.hpp"
 #include "rive/shapes/straight_vertex.hpp"
+#include "rive/math/math_types.hpp"
 #include <cmath>
 #include <cstdio>
 
@@ -20,8 +21,8 @@ void Star::buildPolygon() {
     auto oy = -originY() * height() + halfHeight;
 
     std::size_t length = vertexCount();
-    auto angle = -M_PI / 2;
-    auto inc = 2 * M_PI / length;
+    auto angle = -math::PI / 2;
+    auto inc = 2 * math::PI / length;
 
     for (std::size_t i = 0; i < length; i += 2) {
         {


### PR DESCRIPTION
Turns out, M_PI is not officially required to be in math.h or cmath, so we define our own. (building in google's skia discovered this).

While we're at it, we also define it to explicitly be a float (not a double).

This does create some tiny differences, as some of our math is different (not using the double pi). I posit these are effectively arbitrary, and think the faster, more consistent float version is fine. Happy to discuss more...